### PR TITLE
Remove all PHP closing tags from all files ends as they can cause problems

### DIFF
--- a/source/Autoload.php
+++ b/source/Autoload.php
@@ -39,4 +39,3 @@ function includeDir($path) {
   }
 
 }
-?>

--- a/source/Catapult.php
+++ b/source/Catapult.php
@@ -46,5 +46,3 @@ $dirs = array("utils", "core", "resource", "models", "baml", "events", "types");
 foreach ($dirs as $d) {
     includeDir(realpath(__DIR__ . "/$d"));
 }
-
-?>

--- a/source/baml/BaMLAssert.php
+++ b/source/baml/BaMLAssert.php
@@ -10,5 +10,3 @@
  */
 namespace Catapult;
 abstract class BaMLAssert {}
-
-?>

--- a/source/baml/BaMLAttribute.php
+++ b/source/baml/BaMLAttribute.php
@@ -22,4 +22,3 @@ final class BaMLAttribute extends BaMLAssert {
       return $this->key;
     }
 }
-?>

--- a/source/baml/BaMLBase.php
+++ b/source/baml/BaMLBase.php
@@ -16,4 +16,3 @@ abstract class BaMLGeneric {
         return (string) $this->text;
     }
 }
-?>

--- a/source/baml/BaMLContainer.php
+++ b/source/baml/BaMLContainer.php
@@ -35,4 +35,3 @@ class BaMLContainer extends BaMLGeneric {
         $this->type = $type;
       }
 }
-?>

--- a/source/baml/BaMLText.php
+++ b/source/baml/BaMLText.php
@@ -13,4 +13,3 @@ final class BaMLText extends BaMLAssert {
         return $this->text;
     }
 }
-?>

--- a/source/baml/BaMLVerb.php
+++ b/source/baml/BaMLVerb.php
@@ -339,5 +339,3 @@ class BaMLVerb extends BaMLGeneric {
       $this->text = $text;
     }
 }
-
-?>

--- a/source/baml/BaMLVerbExt.php
+++ b/source/baml/BaMLVerbExt.php
@@ -72,5 +72,3 @@ final class BaMLRedirect extends BaMLVerbRedirect {}
 final class BaMLGather extends BaMLVerbGather {}
 final class BaMLSendMessage extends BaMLVerbSendMessage {}
 final class BaMLHangup extends BaMLVerbHangup {}
-
-?>

--- a/source/core/Client.php
+++ b/source/core/Client.php
@@ -426,4 +426,3 @@ final class Client {
     }
           
 }
-?>

--- a/source/core/Collections.php
+++ b/source/core/Collections.php
@@ -690,5 +690,3 @@ final class DataPacketCollection {
       return $data;
     }
 }
-
-?>

--- a/source/core/Constants.php
+++ b/source/core/Constants.php
@@ -123,5 +123,3 @@ interface BAML_XML_OPTIONS {
 interface BAML_SETTINGS {
   const BAML_VERSION = "";
 }
-
-?>

--- a/source/core/Credentials.php
+++ b/source/core/Credentials.php
@@ -227,4 +227,3 @@ final class Credentials {
     }
 
 }
-?>

--- a/source/core/Exception.php
+++ b/source/core/Exception.php
@@ -81,4 +81,3 @@ class CatapultApiWarning {
       return "CatapultWarning: " . $this->message . "\n";
     }
 }
-?>

--- a/source/core/Log.php
+++ b/source/core/Log.php
@@ -166,5 +166,3 @@ final class Log {
       return self::$on = $on;
     }
   }
-
-?>

--- a/source/core/States.php
+++ b/source/core/States.php
@@ -99,5 +99,3 @@ interface TRANSCRIPTION_STATES {
   const complete = "complete";
   const error = "error";
 }
-
-?>

--- a/source/events/Base.php
+++ b/source/events/Base.php
@@ -304,5 +304,3 @@ class EventType extends Event {
       return $this->model->$prop;
     }
 }
-
-?>

--- a/source/events/CallAnswerEvent.php
+++ b/source/events/CallAnswerEvent.php
@@ -15,4 +15,3 @@ final class AnswerCallEvent extends EventType {
       parent::_init($data, new Call);
     }
 }
-?>

--- a/source/events/CallEvent.php
+++ b/source/events/CallEvent.php
@@ -32,5 +32,3 @@ class CallEvent extends EventType {
       return parent::_init($data, new Call);
     }	
 }
-
-?>

--- a/source/events/ConferenceEvent.php
+++ b/source/events/ConferenceEvent.php
@@ -25,4 +25,3 @@ class ConferenceEventMixin extends EventType {
       return parent::_init($data, new Conference);
     }
 }
-?>

--- a/source/events/ConferenceMemberEvent.php
+++ b/source/events/ConferenceMemberEvent.php
@@ -21,4 +21,3 @@ final class ConferenceMemberEvent extends ConferenceEventMixin {
       return new ConferenceMember($data);
     }
 }
-?>

--- a/source/events/ConferencePlaybackEvent.php
+++ b/source/events/ConferencePlaybackEvent.php
@@ -15,4 +15,3 @@ final class ConferencePlaybackEvent extends EventType {
 		parent::_init($data, new Conference);
 	}
 }
-?>

--- a/source/events/DtmfCallEvent.php
+++ b/source/events/DtmfCallEvent.php
@@ -20,4 +20,3 @@ final class DtmfCallEvent extends EventType {
     parent::_init($data, new Call);
   }
 }
-?>

--- a/source/events/ErrorCallEvent.php
+++ b/source/events/ErrorCallEvent.php
@@ -24,4 +24,3 @@ final class ErrorCallEvent extends EventType {
       parent::_init($data, new Call);
     }
 }
-?>

--- a/source/events/GatherEvent.php
+++ b/source/events/GatherEvent.php
@@ -24,4 +24,3 @@ final class GatherCallEvent extends EventType {
       parent::_init($data, new Gather);
     }
 }
-?>

--- a/source/events/IncomingCallEvent.php
+++ b/source/events/IncomingCallEvent.php
@@ -16,4 +16,3 @@ final class IncomingCallEvent extends EventType {
       parent::_init($data, new Call);
     }
 }
-?>

--- a/source/events/MessageEvent.php
+++ b/source/events/MessageEvent.php
@@ -19,4 +19,3 @@ final class MessageEvent extends EventType {
       parent::_init($data, new Message); 
     }
 }
-?>

--- a/source/events/PlaybackCallEvent.php
+++ b/source/events/PlaybackCallEvent.php
@@ -14,4 +14,3 @@ final class PlaybackCallEvent extends EventType {
       parent::_init($data, new Call);
     }
 }
-?>

--- a/source/events/RecordingCallEvent.php
+++ b/source/events/RecordingCallEvent.php
@@ -21,5 +21,3 @@ class RecordingCallEvent extends EventType {
       parent::_init($data, new Recording);
     }	
 }
-
-?>

--- a/source/events/RejectCallEvent.php
+++ b/source/events/RejectCallEvent.php
@@ -14,4 +14,3 @@ final class RejectCallEvent extends EventType {
       parent::_init($data, new Call);
     }
 }
-?>

--- a/source/events/SpeakCallEvent.php
+++ b/source/events/SpeakCallEvent.php
@@ -16,4 +16,3 @@ final class SpeakCallEvent extends EventType {
       parent::_init($data, new Call);
     }
 }
-?>

--- a/source/events/TimeoutCallEvent.php
+++ b/source/events/TimeoutCallEvent.php
@@ -15,4 +15,3 @@ final class TimeoutCallEvent extends EventType {
       parent::_init($data, new Call);
     }
 }
-?>

--- a/source/events/TranscriptionEvent.php
+++ b/source/events/TranscriptionEvent.php
@@ -23,4 +23,3 @@ class TranscriptionCallEvent extends EventType {
       parent::_init($data, new Transcription);
     }
 }
-?>

--- a/source/models/Account.php
+++ b/source/models/Account.php
@@ -42,6 +42,3 @@ final class Account extends GenericResource {
       return (float) $this->get()->balance();
     }
 }
-
-
-?>

--- a/source/models/Application.php
+++ b/source/models/Application.php
@@ -54,8 +54,3 @@ final class Application extends GenericResource {
       return Constructor::make($this, array("id" => $this->id), TRUE);
     }
 } 
-
-
-
-
-?>

--- a/source/models/Bridge.php
+++ b/source/models/Bridge.php
@@ -103,5 +103,3 @@ final class Bridge Extends GenericResource {
       return URIResource::Make($this->path, array($this->id, "audio"));
     }
 }
-
-?>

--- a/source/models/Call.php
+++ b/source/models/Call.php
@@ -199,5 +199,3 @@ final class Call Extends AudioMixin {
     }
 	
 }
-
-?>

--- a/source/models/CallEvents.php
+++ b/source/models/CallEvents.php
@@ -44,4 +44,3 @@ final class CallEvents extends GenericResource {
     );
   }
 }
-?>

--- a/source/models/Conference.php
+++ b/source/models/Conference.php
@@ -90,6 +90,3 @@ final class Conference extends AudioMixin {
       return new ConferenceMember($this->id);
     }
 }
-
-
-?>

--- a/source/models/ConferenceMember.php
+++ b/source/models/ConferenceMember.php
@@ -51,4 +51,3 @@ final class ConferenceMember extends AudioMixin {
       return URIResource::Make($this->path, array($this->conference, "members", "audio"));
     }
 }
-?>

--- a/source/models/Gather.php
+++ b/source/models/Gather.php
@@ -58,5 +58,3 @@ class Gather extends GenericResource {
       return Constructor::Make($this, $data->get());
     }
 }
-
-?>

--- a/source/models/Media.php
+++ b/source/models/Media.php
@@ -135,4 +135,3 @@ final class Media extends GenericResource {
       return FileHandler::save($filename, $this->data);
     }
 }
-?>

--- a/source/models/Message.php
+++ b/source/models/Message.php
@@ -71,4 +71,3 @@ class Message extends GenericResource {
       return Constructor::Make($this, $data->get(), array("messageId" => "id"));
     }
 }
-?>

--- a/source/models/MessageMulti.php
+++ b/source/models/MessageMulti.php
@@ -104,5 +104,3 @@ class MessageMulti extends GenericResource {
       return $messages;
     }
 }
-
-?>

--- a/source/models/NumberInfo.php
+++ b/source/models/NumberInfo.php
@@ -40,4 +40,3 @@ final class NumberInfo extends GenericResource {
       return Constructor::Make($this, $data);
     }
 }
-?>

--- a/source/models/Plural.php
+++ b/source/models/Plural.php
@@ -108,5 +108,3 @@ final class EndpointsCollection extends CollectionObject {
     return "Endpoints";
   }
 }
-
-?>

--- a/source/models/Recording.php
+++ b/source/models/Recording.php
@@ -50,4 +50,3 @@ final class Recording extends GenericResource {
       return $media;
     }
 }
-?>

--- a/source/models/Transaction.php
+++ b/source/models/Transaction.php
@@ -34,6 +34,3 @@ final class Transaction extends GenericResource {
       );
     }
 }
-
-
-?>

--- a/source/models/Transcription.php
+++ b/source/models/Transcription.php
@@ -86,6 +86,3 @@ final class Transcription extends GenericResource {
       ));
     }
 }
-
-
-?>

--- a/source/models/UserError.php
+++ b/source/models/UserError.php
@@ -28,4 +28,3 @@ final class UserError Extends GenericResource {
       );
     }
 }
-?>

--- a/source/resource/Base.php
+++ b/source/resource/Base.php
@@ -473,5 +473,3 @@ class GenericResource {
       return $proto;
    }
 }
-
-?>

--- a/source/resource/Constructor.php
+++ b/source/resource/Constructor.php
@@ -82,5 +82,3 @@ class Constructor {
       return $class;
     }
 }
-
-?>

--- a/source/resource/Ensure.php
+++ b/source/resource/Ensure.php
@@ -113,4 +113,3 @@ class EnsureResource extends BaseResource {
 }
 
 final class Ensure extends EnsureResource {}
-?>

--- a/source/resource/Event.php
+++ b/source/resource/Event.php
@@ -61,5 +61,3 @@ final class EventResource extends BaseResource {
       throw new \CatapultApiException("EventType was not found in list of events");
     }
   }
-
-?>

--- a/source/resource/Loads.php
+++ b/source/resource/Loads.php
@@ -19,5 +19,3 @@ final class LoadsResource extends BaseResource {
       $this->silent = $args['silent'];
     }
 }
-
-?>

--- a/source/resource/Misc.php
+++ b/source/resource/Misc.php
@@ -84,6 +84,3 @@ abstract class AudioMixin extends GenericResource {
   public function getAudioUrl()
   { }
 }
-
-
-?>

--- a/source/resource/Path.php
+++ b/source/resource/Path.php
@@ -74,6 +74,3 @@ class PathResource extends BaseResource {
       $object->path = $path . $object->path;
     }
 }
-
-
-?>

--- a/source/resource/Resolver.php
+++ b/source/resource/Resolver.php
@@ -82,5 +82,3 @@ class ResolverResource extends GenericResource {
 
 }
 final class Resolver extends ResolverResource {}
-
-?>

--- a/source/resource/Schema.php
+++ b/source/resource/Schema.php
@@ -19,4 +19,3 @@ class SchemaResource extends BaseResource {
       $this->fields = $opts['fields'];
     }
 }
-?>

--- a/source/resource/Uri.php
+++ b/source/resource/Uri.php
@@ -91,4 +91,3 @@ class StringifyResource extends BaseResource {
 		return self::Make($this->class, $this->options);
 	}
 }
-?>

--- a/source/types/CallCombo.php
+++ b/source/types/CallCombo.php
@@ -33,4 +33,3 @@ final class CallCombo extends Types {
     return implode(",", $this->$call_ids);
   }
 }
-?>

--- a/source/types/Callback.php
+++ b/source/types/Callback.php
@@ -20,6 +20,3 @@ final class Callback extends Types {
       return $this->callback;
     }
 }
-
-
-?>

--- a/source/types/Date.php
+++ b/source/types/Date.php
@@ -31,5 +31,3 @@ final class Date extends Types {
       return $this->date->format(API::API_DATE_FORMAT);	
     }
 }
-
-?>

--- a/source/types/Dtmf.php
+++ b/source/types/Dtmf.php
@@ -54,5 +54,3 @@ final class DTMF extends Types {
       return urlencode($this->dtmf);
     }
 }
-
-?>

--- a/source/types/FileHandler.php
+++ b/source/types/FileHandler.php
@@ -59,4 +59,3 @@ final class FileHandler extends Types {
       return (string) $this->as;
     }
 }
-?>

--- a/source/types/Id.php
+++ b/source/types/Id.php
@@ -75,5 +75,3 @@ final class Id extends Types {
       return (string) $this->id;
     }
 }
-
-?>

--- a/source/types/MediaURL.php
+++ b/source/types/MediaURL.php
@@ -70,5 +70,3 @@ final class MediaURL extends Types {
       return $this->url;
     }
 }
-
-?>

--- a/source/types/Page.php
+++ b/source/types/Page.php
@@ -21,4 +21,3 @@ final class Page extends Types {
       return (string) $this->page;
     }
 }
-?>

--- a/source/types/Parameters.php
+++ b/source/types/Parameters.php
@@ -91,5 +91,3 @@ final class Parameters extends Types {
       return $this->serialize();
     }
 }
-
-?>

--- a/source/types/PhoneCombo.php
+++ b/source/types/PhoneCombo.php
@@ -16,4 +16,3 @@ final class PhoneCombo extends Types {
       return array( "from" => (string) $sender, "to" => (string) $receiver);
     }
 }
-?>

--- a/source/types/PhoneNumber.php
+++ b/source/types/PhoneNumber.php
@@ -36,5 +36,3 @@ final class PhoneNumber extends Types {
       return (string) $this->number;
     }
 }
-
-?>

--- a/source/types/Sentence.php
+++ b/source/types/Sentence.php
@@ -42,5 +42,3 @@ final class Sentence extends Types {
       return $this->Make($this->sentence, TRUE);
     }
 }
-
-?>

--- a/source/types/Size.php
+++ b/source/types/Size.php
@@ -26,5 +26,3 @@ final class Size extends Types {
       return (string) ($this->size);		
     }
 }
-
-?>

--- a/source/types/TextMessage.php
+++ b/source/types/TextMessage.php
@@ -20,4 +20,3 @@ final class TextMessage extends Types {
       return strlen($this->message) >= 160 ? (substr($this->message, 0, 157) . "...") : $this->message;
     }
 } 
-?>

--- a/source/types/Timeout.php
+++ b/source/types/Timeout.php
@@ -27,5 +27,3 @@ final class Timeout extends Types {
       return (string) ($this->in_seconds ? $t : $this->timeout);
     }
 }
-
-?>

--- a/source/utils/Base.php
+++ b/source/utils/Base.php
@@ -236,5 +236,3 @@ class BaseUtilities {
         return $object(API::API_DATE_FORMAT);
       } 
 }
-
-?>

--- a/source/utils/Cleaner.php
+++ b/source/utils/Cleaner.php
@@ -42,6 +42,3 @@ final class Cleaner extends BaseUtilities {
     return $data;
 	}
 }
-
-
-?>

--- a/source/utils/Converter.php
+++ b/source/utils/Converter.php
@@ -23,6 +23,3 @@ final class Converter extends BaseUtilities {
 		return get_object_vars($json);
 	}
 }
-
-
-?>

--- a/source/utils/Locator.php
+++ b/source/utils/Locator.php
@@ -37,4 +37,3 @@ class Locator extends BaseUtilities {
     return $header;
     }	
 }
-?>

--- a/source/utils/Prototype.php
+++ b/source/utils/Prototype.php
@@ -158,5 +158,3 @@ class PrototypeUtility extends BaseUtilities {
     }
 
 }
-
-?>

--- a/source/utils/Title.php
+++ b/source/utils/Title.php
@@ -48,6 +48,3 @@ final class TitleUtility extends BaseUtilities {
       return strtoupper(substr($term, 0, 1)) . strtolower(substr($term, 1, strlen($term)));
     }
 }
-
-
-?>

--- a/source/utils/XML.php
+++ b/source/utils/XML.php
@@ -268,5 +268,3 @@ final class XMLUtility extends BaseUtilities {
       return new $verb; 
     }
 }
-
-?>


### PR DESCRIPTION
Closing a PHP tag in a file that only contains PHP causes output to be generated, and thus headers being sent prematurely. If output_buffering is not set, or set to a low value, this can prevent headers and cookies being sent, and cause some other problems.
See http://stackoverflow.com/questions/4410704/why-would-one-omit-the-close-tag and http://stackoverflow.com/questions/5701747/should-i-close-my-php-tags for more information
@nadirhamid please review and merge this, if you'd like