### PR TITLE
Fixes receiptRequested warning when sending SMS

### DIFF
--- a/source/models/Message.php
+++ b/source/models/Message.php
@@ -34,7 +34,7 @@ class Message extends GenericResource {
           array("fields" => array(
           'id', 'direction', 'callbackUrl', 'callbackTimeout',
           'fallbackUrl', 'from', 'to', 'state', 'time', 'text',
-          'errorMessage', 'tag', 'media'
+          'errorMessage', 'tag', 'media', 'receiptRequested'
            ), "needs" => array("id", "from", "to", "state"))
          ),
          new SubFunctionResource


### PR DESCRIPTION
The Message model was missing the 'receiptRequested' field when instantiating the SchemaResource.

This pull request prevents the following warning when attempting to send a message and using the receiptRequested option:

CatapultWarning: receiptRequested is not a valid term in model Catapult\Message