### PR TITLE
Fixes wrong variable reference in Credentials.php

### DIFF
--- a/source/core/Credentials.php
+++ b/source/core/Credentials.php
@@ -89,8 +89,8 @@ final class Credentials {
       /* only consider parameter init if all provided */
       if (isset(self::$credentials_opts['path'])) {
         /** do not load path twice **/
-        if (!preg_match("/credentials\.json/", $credentials_opts['path'])) {
-        self::$credentials_opts['path'] = self::$credentials_opts['path'] . DIRECTORY_SEPARATOR . self::$credentials_opts['file'];
+        if (!preg_match("/credentials\.json/", self::$credentials_opts['path'])) {
+          self::$credentials_opts['path'] = self::$credentials_opts['path'] . DIRECTORY_SEPARATOR . self::$credentials_opts['file'];
         }
       } else {
         self::$credentials_opts['path'] = realpath(getcwd()) . DIRECTORY_SEPARATOR . self::$credentials_opts['file'];


### PR DESCRIPTION
When attempting to check if the provided path contains the string "credentials.json" it was incorrectly comparing against $credentials_opts instead of self::$credentials_opts