### PR TITLE
fix PhoneNumber.php patch method

### DIFF
--- a/source/models/PhoneNumbers.php
+++ b/source/models/PhoneNumbers.php
@@ -56,16 +56,16 @@ final class PhoneNumbers extends GenericResource {
      * Make the needed changes to 
      * the PhoneNumber. Where
      * set of params can be:
-     * application, 
+     * applicationId, 
      * fallback_number,
      *  
      * @param data: set of valid patching options
      */
     public function patch($data)
     {
-        $app = $data['application'];
+        $app = $data['applicationId'];
         if ($app instanceof Application)
-            $data['application'] = $app->id; 
+            $data['applicationId'] = $app->id; 
         $data = Ensure::Input($data);
         $url = URIResource::Make($this->path, array($this->id));
     


### PR DESCRIPTION
The patch method for the PhoneNumber class originally specified an 'application'. However the code was not modifying the string to be 'applicationId' as required by the API docs (http://ap.bandwidth.com/docs/rest-api/phonenumbers/#resourcePOSTv1usersuserIdphoneNumbersnumberString).

This change updates the the 'key' to 'applicationId'.