### PR TITLE
Setting Omit to static, as that is how it used

### DIFF
--- a/source/utils/Cleaner.php
+++ b/source/utils/Cleaner.php
@@ -23,7 +23,7 @@ final class Cleaner extends BaseUtilities {
   * are undercased
   * @param data 
   */
-	public function Omit($data)
+	public static function Omit($data)
 	{
     $runLevel = 0;
     foreach ($data as $k => $d) {


### PR DESCRIPTION
This is currently throwing an error in PHP 5.6.30+ with 'static' being omitted and it called as: Cleaner::Omit(...)